### PR TITLE
Add support to count tokens for ToolMLMessages 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: 'pip'
           cache-dependency-path: |
             requirements-tests.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: 'pip'
           cache-dependency-path: |
             requirements-tests.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 google-cloud-aiplatform
 tiktoken
 tokenizers>=0.7.0
+melting-schemas==3.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 google-cloud-aiplatform
 tiktoken
 tokenizers>=0.7.0
-melting-schemas==3.2.1

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/TeiaLabs/totokenizers",
     packages=setuptools.find_packages(),
-    python_requires=">=3.11",
+    python_requires=">=3.12",
     install_requires=requirements,
     extras_require=extra_requirements,
     package_data={"": ["*.json"]},

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -1,5 +1,7 @@
 import pytest
-from totokenizers.openai import OpenAITokenizer, ChatMLMessage
+from melting_schemas.completion.buffered_ml_messages import ToolMLMessage
+
+from totokenizers.openai import ChatMLMessage, OpenAITokenizer
 
 
 @pytest.fixture(scope="module")
@@ -23,7 +25,31 @@ def chatml_messages():
     ]
 
 
-def test_gpp4_o(chatml_messages):
+@pytest.fixture(scope="module")
+def tool_call_messages():
+    return [
+        ToolMLMessage(
+            tool_id="abcdef_0",
+            content="Rainy",
+            name="weather",
+            role="tool",
+        ),
+        ToolMLMessage(
+            tool_id="abcdef_1",
+            content="Sunny",
+            name="weather",
+            role="tool",
+        ),
+        ToolMLMessage(
+            tool_id="abcdef_2",
+            content="Cloudy",
+            name="weather",
+            role="tool",
+        ),
+    ]
+
+
+def test_gpp4_o(chatml_messages, tool_call_messages):
     tokenizer = OpenAITokenizer(model_name="gpt-4o-2024-05-13")
 
     count_tokens = tokenizer.count_chatml_tokens(chatml_messages)
@@ -32,4 +58,5 @@ def test_gpp4_o(chatml_messages):
     count_tokens = tokenizer.count_tokens("hello world")
     assert count_tokens == 2
 
-    # TODO: count function call tokens
+    count_tokens = tokenizer.count_chatml_tokens(tool_call_messages)
+    assert count_tokens == 32

--- a/totokenizers/openai.py
+++ b/totokenizers/openai.py
@@ -2,6 +2,7 @@ import logging
 from typing import Mapping, Optional, Sequence
 
 import tiktoken
+from melting_schemas.completion.buffered_ml_messages import ToolMLMessage
 
 from .errors import ModelNotFound, ModelNotSupported
 from .jsonschema_formatter import FunctionJSONSchema
@@ -36,7 +37,10 @@ class OpenAITokenizer:
     ):
         self.model = model_name
         try:
-            if model_name == "ft:gpt-4o-2024-08-06:osf-digital:revenue-cloud-4o:A5s5vXgB":
+            if (
+                model_name
+                == "ft:gpt-4o-2024-08-06:osf-digital:revenue-cloud-4o:A5s5vXgB"
+            ):
                 self.encoder = tiktoken.encoding_for_model("gpt-4o")
             else:
                 self.encoder = tiktoken.encoding_for_model(model_name)
@@ -53,9 +57,9 @@ class OpenAITokenizer:
             "text-davinci-003",
             "gpt-3.5-turbo-instruct",
         ):
-            self.count_chatml_tokens = NotImplementedError
-            self.count_functions_tokens = NotImplementedError
-            self.count_message_tokens = NotImplementedError
+            self.count_chatml_tokens = NotImplementedError  # type: ignore
+            self.count_functions_tokens = NotImplementedError  # type: ignore
+            self.count_message_tokens = NotImplementedError  # type: ignore
             return
 
         if self.model in {
@@ -100,31 +104,39 @@ class OpenAITokenizer:
         return len(self.encode(text))
 
     def count_chatml_tokens(
-        self, messages: Chat, functions: Optional[Sequence[Mapping]] = None
+        self,
+        messages: Chat | Sequence[ToolMLMessage],
+        functions: Optional[Sequence[Mapping]] = None,
     ) -> int:
         num_tokens = sum(map(self.count_message_tokens, messages))
         num_tokens += 3  # every reply is primed with <|start|>assistant<|message|>
         if functions:
-            if messages[0]["role"] == "system":
-                num_tokens -= (
-                    1  # I believe a newline gets removed somewhere for somereason
-                )
-            else:
-                num_tokens += self.tokens_per_message
+            if not isinstance(messages[0], ToolMLMessage):
+                if messages[0]["role"] == "system":
+                    num_tokens -= (
+                        1  # I believe a newline gets removed somewhere for somereason
+                    )
+                else:
+                    num_tokens += self.tokens_per_message
             num_tokens += self.count_functions_tokens(functions)
         return num_tokens
 
     def count_message_tokens(
-        self, message: ChatMLMessage | FunctionCallChatMLMessage | FunctionChatMLMessage
+        self,
+        message: ChatMLMessage
+        | FunctionCallChatMLMessage
+        | FunctionChatMLMessage
+        | ToolMLMessage,
     ) -> int:
         """https://github.com/openai/openai-python/blob/main/chatml.md"""
         num_tokens = self.tokens_per_message
-        if message["role"] == "function":
+
+        if isinstance(message, ToolMLMessage):
             num_tokens += (
-                self.count_tokens(message["content"])
-                + self.count_tokens(message["name"])
-                + self.count_tokens(message["role"])
-                - 1  # omission of a delimiter?
+                self.count_tokens(message.tool_id)
+                + self.count_tokens(message.content)
+                + self.count_tokens(message.name)
+                + self.count_tokens(message.role)
             )
         elif "function_call" in message:
             # https://github.com/forestwanglin/openai-java/blob/308a3423d34905bd28aca976fd0f2fa030f9a3a1/jtokkit/src/main/java/xyz/felh/openai/jtokkit/utils/TikTokenUtils.java#L202-L205

--- a/totokenizers/openai.py
+++ b/totokenizers/openai.py
@@ -138,6 +138,13 @@ class OpenAITokenizer:
                 + self.count_tokens(message.name)
                 + self.count_tokens(message.role)
             )
+        elif message["role"] == "function":
+            num_tokens += (
+                self.count_tokens(message["content"])
+                + self.count_tokens(message["name"])
+                + self.count_tokens(message["role"])
+                - 1  # omission of a delimiter?
+            )
         elif "function_call" in message:
             # https://github.com/forestwanglin/openai-java/blob/308a3423d34905bd28aca976fd0f2fa030f9a3a1/jtokkit/src/main/java/xyz/felh/openai/jtokkit/utils/TikTokenUtils.java#L202-L205
             num_tokens += (


### PR DESCRIPTION
This PR enables the `totokenizers.openai.OpenAITokenizer.count_chatml_tokens` function to count tokens of `ToolMLMessages` by:
- Adding Melting Schemas to `requirements.txt`
- Adding the parameter type of Sequence of `ToolMLMessage` from `melting_schemas` to the function
- Introducing new `if` and `elif` statements to handle the new specific case, while keeping the older ones
- Add tests for ToolMLMessages
